### PR TITLE
Fix star data that have null json objects, bump RL version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.21.1'
+def runeLiteVersion = '1.7.26'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/andmcadams/shootingstars/ShootingStarsDataManager.java
+++ b/src/main/java/com/andmcadams/shootingstars/ShootingStarsDataManager.java
@@ -90,9 +90,14 @@ public class ShootingStarsDataManager
 		for (JsonElement jsonElement : j)
 		{
 			JsonObject jObj = jsonElement.getAsJsonObject();
-			ShootingStarsData d = new ShootingStarsData(ShootingStarsLocation.getLocation(jObj.get("location").getAsInt()),
-				jObj.get("world").getAsInt(), jObj.get("minTime").getAsLong(), jObj.get("maxTime").getAsLong());
-			l.add(d);
+			try
+			{
+				ShootingStarsData d = new ShootingStarsData(ShootingStarsLocation.getLocation(jObj.get("location").getAsInt()),
+						jObj.get("world").getAsInt(), jObj.get("minTime").getAsLong(), jObj.get("maxTime").getAsLong());
+				l.add(d);
+			} catch (UnsupportedOperationException uos) {
+				log.error("Star: " + uos.getLocalizedMessage());
+			}
 		}
 		return l;
 	}


### PR DESCRIPTION
Example: https://sek.ai/stars/get.php has star data that produces null locations, added a try catch block to skip over them.