### PR TITLE
Fix incorrect chatbox widget when looking through telescope

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.andmcadams.shootingstars'
-version = '1.6.3'
+version = '1.6.4'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/andmcadams/shootingstars/ShootingStarsPlugin.java
+++ b/src/main/java/com/andmcadams/shootingstars/ShootingStarsPlugin.java
@@ -47,6 +47,7 @@ import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameTick;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.callback.ClientThread;
@@ -268,15 +269,14 @@ public class ShootingStarsPlugin extends Plugin
 	public void onGameTick(GameTick gameTick)
 	{
 		handleHop();
-
-		Widget chatbox = client.getWidget(229, 1);
-		if (chatbox != null)
+		Widget messageBoxTextWidget = client.getWidget(InterfaceID.Messagebox.TEXT);
+		if (messageBoxTextWidget != null)
 		{
 			int world = client.getWorld();
-			ShootingStarsLocation loc = ShootingStarsLocation.determineLocation(chatbox.getText());
+			ShootingStarsLocation loc = ShootingStarsLocation.determineLocation(messageBoxTextWidget.getText());
 			if (world != lastWorld || (loc != null && loc != lastLoc))
 			{
-				String text = chatbox.getText();
+				String text = messageBoxTextWidget.getText();
 				text = text.replace("<br>", " ");
 
 				Matcher m = firstMinThenHour.matcher(text);


### PR DESCRIPTION
- The previously used chatbox widget no longer contains the text used to parse region and time. Updated to use the now correct InterfaceID.Messagebox.TEXT
- Bump version to 1.6.4

Tested on a few worlds and the list now properly populates when looking through a telescope again.
<img width="283" height="183" alt="Screenshot 2025-07-23 163822" src="https://github.com/user-attachments/assets/69faf771-7a1d-41a6-beac-e489fcc20293" />
